### PR TITLE
Fix navbar stylesheet loading in GitHub Pages production

### DIFF
--- a/docs/components/organisms/Navbar.js
+++ b/docs/components/organisms/Navbar.js
@@ -14,7 +14,7 @@ class Navbar extends HTMLElement {
         rel="stylesheet"
         href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css"
       />
-      <link rel="stylesheet" href="../styles/organisms/Navbar.css" />
+      <link rel="stylesheet" href="./styles/organisms/Navbar.css" />
       <nav class="navbar">
         <img class="navbar__logo" src="./icons/logo.png" />
         <img class="navbar__open-btn navbar__options animate__animated" src="./icons/menu.png" />

--- a/src/components/organisms/Navbar.ts
+++ b/src/components/organisms/Navbar.ts
@@ -15,7 +15,7 @@ class Navbar extends HTMLElement {
         rel="stylesheet"
         href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css"
       />
-      <link rel="stylesheet" href="../styles/organisms/Navbar.css" />
+      <link rel="stylesheet" href="./styles/organisms/Navbar.css" />
       <nav class="navbar">
         <img class="navbar__logo" src="./icons/logo.png" />
         <img class="navbar__open-btn navbar__options animate__animated" src="./icons/menu.png" />


### PR DESCRIPTION
### Motivation
- The navbar stylesheet was not loading on GitHub Pages because the shadow DOM `link` used `../styles/organisms/Navbar.css`, which resolves outside the project base path on project pages (causing 404s). 

### Description
- Updated the stylesheet URL in the navbar component from `../styles/organisms/Navbar.css` to `./styles/organisms/Navbar.css` in `src/components/organisms/Navbar.ts` so it resolves relative to the published `docs/` site. 
- Rebuilt the project so the generated artifact `docs/components/organisms/Navbar.js` was regenerated with the corrected path. 
- Committed the updated TypeScript source and the regenerated `docs` file. 

### Testing
- Ran the site build with `npm run build`, which completed successfully. 
- Verified that `docs/components/organisms/Navbar.js` contains the corrected `./styles/organisms/Navbar.css` reference.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c698c695248322bc431633627f6797)