### PR TITLE
Fix component stylesheet paths to use './styles' relative links

### DIFF
--- a/docs/components/atoms/GridIcon.js
+++ b/docs/components/atoms/GridIcon.js
@@ -24,7 +24,7 @@ class GridIcon extends HTMLElement {
             const link = document.createElement('link');
             link.id = 'grid-icon-styles';
             link.rel = 'stylesheet';
-            link.href = '../styles/atoms/GridIcon.css';
+            link.href = './styles/atoms/GridIcon.css';
             document.head.appendChild(link);
         }
     }

--- a/docs/components/atoms/IconLink.js
+++ b/docs/components/atoms/IconLink.js
@@ -30,7 +30,7 @@ class IconLink extends HTMLElement {
             const link = document.createElement('link');
             link.id = 'icon-link-styles';
             link.rel = 'stylesheet';
-            link.href = '../styles/atoms/IconLink.css';
+            link.href = './styles/atoms/IconLink.css';
             document.head.appendChild(link);
         }
     }

--- a/docs/components/molecules/CardExperience.js
+++ b/docs/components/molecules/CardExperience.js
@@ -9,7 +9,7 @@ class CardExperience extends HTMLElement {
             const link = document.createElement('link');
             link.id = 'card-experience-styles';
             link.rel = 'stylesheet';
-            link.href = '../styles/molecules/CardExperience.css';
+            link.href = './styles/molecules/CardExperience.css';
             document.head.appendChild(link);
         }
     }

--- a/docs/components/molecules/Presentation.js
+++ b/docs/components/molecules/Presentation.js
@@ -9,7 +9,7 @@ class Presentation extends HTMLElement {
             const link = document.createElement('link');
             link.id = 'presentation-styles';
             link.rel = 'stylesheet';
-            link.href = '../styles/molecules/Presentation.css';
+            link.href = './styles/molecules/Presentation.css';
             document.head.appendChild(link);
         }
     }

--- a/docs/components/organisms/About.js
+++ b/docs/components/organisms/About.js
@@ -9,7 +9,7 @@ class About extends HTMLElement {
             const link = document.createElement('link');
             link.id = 'about-styles';
             link.rel = 'stylesheet';
-            link.href = '../styles/organisms/About.css';
+            link.href = './styles/organisms/About.css';
             document.head.appendChild(link);
         }
     }

--- a/docs/components/organisms/ExperienceSection.js
+++ b/docs/components/organisms/ExperienceSection.js
@@ -13,7 +13,7 @@ class ExperienceSection extends HTMLElement {
             const link = document.createElement('link');
             link.id = 'experience-section-styles';
             link.rel = 'stylesheet';
-            link.href = '../styles/organisms/ExperienceSection.css';
+            link.href = './styles/organisms/ExperienceSection.css';
             document.head.appendChild(link);
         }
     }

--- a/docs/components/organisms/Footer.js
+++ b/docs/components/organisms/Footer.js
@@ -12,7 +12,7 @@ class Footer extends HTMLElement {
             const link = document.createElement('link');
             link.id = 'footer-styles';
             link.rel = 'stylesheet';
-            link.href = '../styles/organisms/Footer.css';
+            link.href = './styles/organisms/Footer.css';
             document.head.appendChild(link);
         }
     }

--- a/docs/components/organisms/Header.js
+++ b/docs/components/organisms/Header.js
@@ -11,7 +11,7 @@ class Header extends HTMLElement {
             const link = document.createElement('link');
             link.id = 'header-styles';
             link.rel = 'stylesheet';
-            link.href = '../styles/organisms/Header.css';
+            link.href = './styles/organisms/Header.css';
             document.head.appendChild(link);
         }
     }

--- a/docs/components/organisms/Navbar.js
+++ b/docs/components/organisms/Navbar.js
@@ -14,7 +14,7 @@ class Navbar extends HTMLElement {
         rel="stylesheet"
         href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css"
       />
-      <link rel="stylesheet" href="../styles/organisms/Navbar.css" />
+      <link rel="stylesheet" href="./styles/organisms/Navbar.css" />
       <nav class="navbar">
         <img class="navbar__logo" src="./icons/logo.png" />
         <img class="navbar__open-btn navbar__options animate__animated" src="./icons/menu.png" />

--- a/docs/components/organisms/ProjectCard.js
+++ b/docs/components/organisms/ProjectCard.js
@@ -10,7 +10,7 @@ class ProjectCard extends HTMLElement {
             const link = document.createElement('link');
             link.id = 'project-card-styles';
             link.rel = 'stylesheet';
-            link.href = '../styles/organisms/ProjectCard.css';
+            link.href = './styles/organisms/ProjectCard.css';
             document.head.appendChild(link);
         }
     }

--- a/docs/components/organisms/ProjectsSection.js
+++ b/docs/components/organisms/ProjectsSection.js
@@ -10,7 +10,7 @@ class ProjectsSection extends HTMLElement {
             const link = document.createElement('link');
             link.id = 'projects-section-styles';
             link.rel = 'stylesheet';
-            link.href = '../styles/organisms/ProjectsSection.css';
+            link.href = './styles/organisms/ProjectsSection.css';
             document.head.appendChild(link);
         }
     }

--- a/docs/components/organisms/SkillsSection.js
+++ b/docs/components/organisms/SkillsSection.js
@@ -10,7 +10,7 @@ class SkillsSection extends HTMLElement {
             const link = document.createElement('link');
             link.id = 'skills-section-styles';
             link.rel = 'stylesheet';
-            link.href = '../styles/organisms/SkillsSection.css';
+            link.href = './styles/organisms/SkillsSection.css';
             document.head.appendChild(link);
         }
     }

--- a/src/components/atoms/GridIcon.ts
+++ b/src/components/atoms/GridIcon.ts
@@ -28,7 +28,7 @@ class GridIcon extends HTMLElement {
       const link = document.createElement('link');
       link.id = 'grid-icon-styles';
       link.rel = 'stylesheet';
-      link.href = '../styles/atoms/GridIcon.css';
+      link.href = './styles/atoms/GridIcon.css';
       document.head.appendChild(link);
     }
   }

--- a/src/components/atoms/IconLink.ts
+++ b/src/components/atoms/IconLink.ts
@@ -35,7 +35,7 @@ class IconLink extends HTMLElement {
       const link = document.createElement('link');
       link.id = 'icon-link-styles';
       link.rel = 'stylesheet';
-      link.href = '../styles/atoms/IconLink.css';
+      link.href = './styles/atoms/IconLink.css';
       document.head.appendChild(link);
     }
   }

--- a/src/components/molecules/CardExperience.ts
+++ b/src/components/molecules/CardExperience.ts
@@ -9,7 +9,7 @@ class CardExperience extends HTMLElement {
       const link = document.createElement('link');
       link.id = 'card-experience-styles';
       link.rel = 'stylesheet';
-      link.href = '../styles/molecules/CardExperience.css';
+      link.href = './styles/molecules/CardExperience.css';
       document.head.appendChild(link);
     }
   }

--- a/src/components/molecules/Presentation.ts
+++ b/src/components/molecules/Presentation.ts
@@ -9,7 +9,7 @@ class Presentation extends HTMLElement {
       const link = document.createElement('link');
       link.id = 'presentation-styles';
       link.rel = 'stylesheet';
-      link.href = '../styles/molecules/Presentation.css';
+      link.href = './styles/molecules/Presentation.css';
       document.head.appendChild(link);
     }
   }

--- a/src/components/organisms/About.ts
+++ b/src/components/organisms/About.ts
@@ -9,7 +9,7 @@ class About extends HTMLElement {
       const link = document.createElement('link');
       link.id = 'about-styles';
       link.rel = 'stylesheet';
-      link.href = '../styles/organisms/About.css';
+      link.href = './styles/organisms/About.css';
       document.head.appendChild(link);
     }
   }

--- a/src/components/organisms/ExperienceSection.ts
+++ b/src/components/organisms/ExperienceSection.ts
@@ -16,7 +16,7 @@ class ExperienceSection extends HTMLElement {
       const link = document.createElement('link');
       link.id = 'experience-section-styles';
       link.rel = 'stylesheet';
-      link.href = '../styles/organisms/ExperienceSection.css';
+      link.href = './styles/organisms/ExperienceSection.css';
       document.head.appendChild(link);
     }
   }

--- a/src/components/organisms/Footer.ts
+++ b/src/components/organisms/Footer.ts
@@ -15,7 +15,7 @@ class Footer extends HTMLElement {
       const link = document.createElement('link');
       link.id = 'footer-styles';
       link.rel = 'stylesheet';
-      link.href = '../styles/organisms/Footer.css';
+      link.href = './styles/organisms/Footer.css';
       document.head.appendChild(link);
     }
   }

--- a/src/components/organisms/Header.ts
+++ b/src/components/organisms/Header.ts
@@ -13,7 +13,7 @@ class Header extends HTMLElement {
       const link = document.createElement('link');
       link.id = 'header-styles';
       link.rel = 'stylesheet';
-      link.href = '../styles/organisms/Header.css';
+      link.href = './styles/organisms/Header.css';
       document.head.appendChild(link);
     }
   }

--- a/src/components/organisms/Navbar.ts
+++ b/src/components/organisms/Navbar.ts
@@ -15,7 +15,7 @@ class Navbar extends HTMLElement {
         rel="stylesheet"
         href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css"
       />
-      <link rel="stylesheet" href="../styles/organisms/Navbar.css" />
+      <link rel="stylesheet" href="./styles/organisms/Navbar.css" />
       <nav class="navbar">
         <img class="navbar__logo" src="./icons/logo.png" />
         <img class="navbar__open-btn navbar__options animate__animated" src="./icons/menu.png" />

--- a/src/components/organisms/ProjectCard.ts
+++ b/src/components/organisms/ProjectCard.ts
@@ -10,7 +10,7 @@ class ProjectCard extends HTMLElement {
       const link = document.createElement('link');
       link.id = 'project-card-styles';
       link.rel = 'stylesheet';
-      link.href = '../styles/organisms/ProjectCard.css';
+      link.href = './styles/organisms/ProjectCard.css';
       document.head.appendChild(link);
     }
   }

--- a/src/components/organisms/ProjectsSection.ts
+++ b/src/components/organisms/ProjectsSection.ts
@@ -12,7 +12,7 @@ class ProjectsSection extends HTMLElement {
       const link = document.createElement('link');
       link.id = 'projects-section-styles';
       link.rel = 'stylesheet';
-      link.href = '../styles/organisms/ProjectsSection.css';
+      link.href = './styles/organisms/ProjectsSection.css';
       document.head.appendChild(link);
     }
   }

--- a/src/components/organisms/SkillsSection.ts
+++ b/src/components/organisms/SkillsSection.ts
@@ -19,7 +19,7 @@ class SkillsSection extends HTMLElement {
       const link = document.createElement('link');
       link.id = 'skills-section-styles';
       link.rel = 'stylesheet';
-      link.href = '../styles/organisms/SkillsSection.css';
+      link.href = './styles/organisms/SkillsSection.css';
       document.head.appendChild(link);
     }
   }


### PR DESCRIPTION
### Motivation
- Fix incorrect stylesheet link paths so components load their CSS from the correct relative location when rendered from the component files. 

### Description
- Updated stylesheet `href` values from `../styles/...` to `./styles/...` across component files in both `src` and `docs` so CSS is resolved relative to the component files. 
- Affected components include atoms (`GridIcon`, `IconLink`), molecules (`CardExperience`, `Presentation`), and organisms (`About`, `ExperienceSection`, `Footer`, `Header`, `Navbar`, `ProjectCard`, `ProjectsSection`, `SkillsSection`) in both `src/components/...` and `docs/components/...`. 
- Adjusted the `<link>` in `Navbar` shadow DOM to use the same `./styles/organisms/Navbar.css` path. 
- Kept component logic unchanged; only the stylesheet path strings were modified.

### Testing
- No automated tests were added or modified for this change.

------